### PR TITLE
GitHub action as CI - Fix all supported rubies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
         env:
-          BUNDLE_WITHOUT: docs
+          BUNDLE_WITHOUT: documentation
       - run: echo "{RUBYOPT}={--enable-frozen-string-literal}" >> $GITHUB_ENV
         if: ${{ matrix.frozen-string }}
-      - run: bundle exec rake test
+      - run: bundle exec rake test --trace
         env:
           RUBYARCHDIR: './lib'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,34 +18,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', 'truffleruby']
+        ruby-version: ['2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', 'truffleruby', 'jruby']
         allow-failure: [false]
         frozen-string: [true]
         include:
           - ruby-version: 'head'
             allow-failure: true
             frozen-string: true
-          # issue with redcarpet gem installation
-          - ruby-version: 'jruby'
-            allow-failure: true
-            frozen-string: true
-          # Issue with squiggly heredoc affecting main/master and 0.3: https://github.com/mimemagicrb/mimemagic/pull/150/files 
-          # Either fix that or remove 2.2 support in main/master
-          - ruby-version: '2.2'
-            allow-failure: true
-            frozen-string: false
-          # minitest requirement is breaking this job
-          # Issue with squiggly heredoc affecting main/master and 0.3: https://github.com/mimemagicrb/mimemagic/pull/150/files 
-          #   Either fix that or remove 2.2 support in main/master
-          - ruby-version: '2.1'
-            allow-failure: true
-            frozen-string: false
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        env:
+          BUNDLE_WITHOUT: docs
       - run: echo "{RUBYOPT}={--enable-frozen-string-literal}" >> $GITHUB_ENV
         if: ${{ matrix.frozen-string }}
       - run: bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,6 @@ gemspec
 gem 'yard'
 gem 'redcarpet'
 gem 'github-markup'
+gem 'minitest', '~> 5.11.0'
+gem 'nokogiri', '~> 1.9.0'
+gem 'rake', '~> 12.3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,12 @@
 source 'https://rubygems.org/'
 gemspec
 
-gem 'yard'
-gem 'redcarpet'
-gem 'github-markup'
 gem 'minitest', '~> 5.11.0'
 gem 'nokogiri', '~> 1.9.0'
 gem 'rake', '~> 12.3.0'
+
+group :doc do
+  gem 'yard'
+  gem 'redcarpet'
+  gem 'github-markup'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'minitest', '~> 5.11.0'
 gem 'nokogiri', '~> 1.9.0'
 gem 'rake', '~> 12.3.0'
 
-group :doc do
+group :documentation do
   gem 'yard'
   gem 'redcarpet'
   gem 'github-markup'

--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -25,6 +25,7 @@ desc "Build a file pointing at the database"
 task :default do
   mime_database_path = locate_mime_database
   target_dir = "#{ENV.fetch("RUBYARCHDIR", "../lib")}/mimemagic"
+  puts target_dir
   mkdir_p target_dir
 
   open("#{target_dir}/path.rb", "w") do |f|

--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -28,7 +28,7 @@ task :default do
   mkdir_p target_dir
 
   open("#{target_dir}/path.rb", "w") do |f|
-    f.print(<<~SOURCE
+    f.print(<<-SOURCE.gsub(/^ {3}/, "")
       class MimeMagic
         DATABASE_PATH="#{mime_database_path}"
       end

--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -25,8 +25,18 @@ desc "Build a file pointing at the database"
 task :default do
   mime_database_path = locate_mime_database
   target_dir = "#{ENV.fetch("RUBYARCHDIR", "../lib")}/mimemagic"
-  puts target_dir
-  mkdir_p target_dir
+  begin
+    mkdir_p target_dir
+  rescue ArgumentError
+    #
+    # rake >= 13 required on Ruby >= 3.0 due to the hash keyword argument deprecation:
+    # https://github.com/ruby/rake/commit/baa23cc8a8cc624bc8f46c8a55d2f0caade568ea#diff-a8d48595711725bd3c49e3c84f736b0ac6a0da37cc13ceb49c7ff4f815014cfb
+    #
+    # This means we're not using `verbose` and `nowrite` rake features for this
+    # To be cleaned with required_ruby_version >= 2.2 or rake >= 13
+    #
+    FileUtils.mkdir_p target_dir
+  end
 
   open("#{target_dir}/path.rb", "w") do |f|
     f.print(<<-SOURCE.gsub(/^ {3}/, "")

--- a/mimemagic.gemspec
+++ b/mimemagic.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/mimemagicrb/mimemagic'
   s.license = 'MIT'
 
-  s.required_ruby_version = '>= 2.1.0'
+  s.required_ruby_version = Gem::Requirement.new('>= 2.1.0'.freeze)
 
   s.add_dependency('nokogiri', '~> 1')
   s.add_dependency('rake')

--- a/mimemagic.gemspec
+++ b/mimemagic.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/mimemagicrb/mimemagic'
   s.license = 'MIT'
 
+  s.required_ruby_version = '>= 2.1.0'
+
   s.add_dependency('nokogiri', '~> 1')
   s.add_dependency('rake')
-
-  s.add_development_dependency('minitest', '~> 5.14')
 
   if s.respond_to?(:metadata)
     s.metadata['changelog_uri'] = "https://github.com/mimemagicrb/mimemagic/blob/master/CHANGELOG.md"


### PR DESCRIPTION
Extended from https://github.com/mimemagicrb/mimemagic/pull/122 to fix all ruby versions.

* Explicit ruby version requirement
* Removed squiggly heredoc to fix ruby 2.1 and 2.2
* Moved dependencies from gemspec to Gemfile. After revisiting https://github.com/rubygems/rubygems/issues/1104 and checking some of the popular ruby gems I think could be better to define this type of dependencies in the Gemfile, even if Gemfile.lock is gitignored in this project. 
* Fixed jruby by making redcarpet an optional bundle group in the CI job.
* Workaround for ruby >= 3.0 and rake < 13